### PR TITLE
Only catch module not found errors

### DIFF
--- a/server/server.py
+++ b/server/server.py
@@ -428,7 +428,7 @@ if __name__ == '__main__':
     try:
         LED  = LED.LED()
         LED.colorWipe(Color(255,16,0))
-    except:
+    except ModuleNotFoundError as e:
         print('Use "sudo pip3 install rpi_ws281x" to install WS_281x package')
         pass
 

--- a/server/serverTest.py
+++ b/server/serverTest.py
@@ -280,7 +280,7 @@ if __name__ == '__main__':
     try:
         LED  = LED.LED()
         LED.colorWipe(Color(255,16,0))
-    except:
+    except ModuleNotFoundError as e:
         print('Use "sudo pip3 install rpi_ws281x" to install WS_281x package')
         pass
 

--- a/server/webServer.py
+++ b/server/webServer.py
@@ -505,7 +505,7 @@ if __name__ == '__main__':
         RL=robotLight.RobotLight()
         RL.start()
         RL.breath(70,70,255)
-    except:
+    except ModuleNotFoundError as e:
         print('Use "sudo pip3 install rpi_ws281x" to install WS_281x package\n使用"sudo pip3 install rpi_ws281x"命令来安装rpi_ws281x')
         pass
 


### PR DESCRIPTION
This is misleadingly telling users to install a library even if the library is installed and there is some other problem